### PR TITLE
mainnet/testnet & timeout changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tonic = { version = "0.12", features = ["tls", "tls-roots"] }
 prost = "0.13"
 tokio-stream = "0.1"
 semver = "1.0"
+chrono = "0.4"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 image = "0.24"

--- a/config.toml
+++ b/config.toml
@@ -9,3 +9,6 @@ password = "password"
 
 [quorum]
 previous_blocks_offset = 8
+
+[network]
+network = "testnet"

--- a/src/grpc_client.rs
+++ b/src/grpc_client.rs
@@ -27,7 +27,8 @@ pub async fn check_node_version(address: &str, port: u16) -> Result<VersionCheck
     
     let channel = Channel::from_shared(endpoint)?
         .tls_config(tls)?
-        .timeout(Duration::from_secs(5))
+        .timeout(Duration::from_secs(2))
+        .connect_timeout(Duration::from_secs(2))
         .connect()
         .await?;
     
@@ -41,7 +42,7 @@ pub async fn check_node_version(address: &str, port: u16) -> Result<VersionCheck
     
     // Make the request with a timeout
     let response = tokio::time::timeout(
-        Duration::from_secs(5),
+        Duration::from_secs(2),
         client.get_status(request)
     ).await??;
     

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Configuration loaded:");
     println!("  Server: {}:{}", config.server.host, config.server.port);
     println!("  RPC: {} (user: {})", config.rpc.url, config.rpc.username);
+    println!("  Network: {}", config.network.network);
+    println!("  LLMQ Type: {} (ID: {})", config.get_llmq_type(), config.get_llmq_type_id());
+    println!("  DAPI Port: {}", config.get_dapi_port());
     println!("  Previous blocks offset: {}", config.quorum.previous_blocks_offset);
     
     // Load initial quorums from Dash Core
@@ -42,6 +45,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     
     // Create masternode cache
     let masternode_cache = Arc::new(MasternodeCache::new(config.clone()));
+    
+    // Populate masternode cache on startup
+    println!("Loading initial masternode list...");
+    match masternode_cache.get_masternodes().await {
+        Ok(masternodes) => {
+            println!("Successfully loaded {} masternodes into cache", masternodes.len());
+        }
+        Err(e) => {
+            eprintln!("Warning: Failed to load initial masternodes: {}. Cache will populate on first request.", e);
+        }
+    }
     
     // Start background refresh for masternode cache
     masternode_cache.clone().start_background_refresh().await;

--- a/src/quorum_loader.rs
+++ b/src/quorum_loader.rs
@@ -27,10 +27,11 @@ pub async fn load_initial_quorums(
     
     let mut quorum_list = QuorumList::new();
     
-    // Parse the extended quorum list - extract llmq_25_67 quorums for testnet
+    // Parse the extended quorum list - extract the appropriate LLMQ type based on network
+    let llmq_type = config.get_llmq_type();
     if let Some(quorum_obj) = result.as_object() {
-        if let Some(llmq_25_67) = quorum_obj.get("llmq_25_67") {
-            if let Some(quorums_arr) = llmq_25_67.as_array() {
+        if let Some(llmq_quorums) = quorum_obj.get(llmq_type) {
+            if let Some(quorums_arr) = llmq_quorums.as_array() {
                 for quorum_item in quorums_arr {
                     if let Some(quorum_obj) = quorum_item.as_object() {
                         for (quorum_hash_str, quorum_info) in quorum_obj {
@@ -40,7 +41,7 @@ pub async fn load_initial_quorums(
                                     // Get the actual quorum public key via quorum info
                                     let rpc_params = [
                                         serde_json::json!("info"), 
-                                        serde_json::json!(6), // llmq_25_67 = type 6
+                                        serde_json::json!(config.get_llmq_type_id()),
                                         serde_json::json!(quorum_hash_str)
                                     ];
                                     println!("DEBUG: Calling quorum with params: {:?}", rpc_params);
@@ -113,10 +114,11 @@ pub async fn load_quorums_at_height(
     
     let mut quorum_list = QuorumList::new();
     
-    // Parse the extended quorum list - extract llmq_25_67 quorums for testnet
+    // Parse the extended quorum list - extract the appropriate LLMQ type based on network
+    let llmq_type = config.get_llmq_type();
     if let Some(quorum_obj) = result.as_object() {
-        if let Some(llmq_25_67) = quorum_obj.get("llmq_25_67") {
-            if let Some(quorums_arr) = llmq_25_67.as_array() {
+        if let Some(llmq_quorums) = quorum_obj.get(llmq_type) {
+            if let Some(quorums_arr) = llmq_quorums.as_array() {
                 for quorum_item in quorums_arr {
                     if let Some(quorum_obj) = quorum_item.as_object() {
                         for (quorum_hash_str, quorum_info) in quorum_obj {
@@ -126,7 +128,7 @@ pub async fn load_quorums_at_height(
                                     // Get the actual quorum public key via quorum info
                                     let rpc_params = [
                                         serde_json::json!("info"), 
-                                        serde_json::json!(6), // llmq_25_67 = type 6
+                                        serde_json::json!(config.get_llmq_type_id()),
                                         serde_json::json!(quorum_hash_str),
                                         serde_json::json!(true) // includeSkShare
                                     ];


### PR DESCRIPTION
* We can now change the config to mainnet or testnet, which will configure certain things internally (ports, LLMQ type, etc)
* Fixed hang on getting masternode list in mainnet, it will now fail much faster if a node is misconfigured