### PR TITLE
[CI] Test rust-dashcore PR #579

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 
 [dependencies]
 # dash-sdk = { git = "https://github.com/dashpay/platform", tag = "v1.8.0" }
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", tag = "v0.40.0", default-features = false, features = [
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "8cbae416458565faac21d3452fbc6d80b324f6d3", default-features = false, features = [
     "std",
     "secp-recovery",
     "bincode",
 ] }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", tag = "v0.40.0" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "8cbae416458565faac21d3452fbc6d80b324f6d3" }
 crossbeam-channel = "0.5.13"
 futures = "0.3.31"
 serde = { version = "1.0.217", features = ["derive"] }


### PR DESCRIPTION
🔧 **Automated integration test** by @dashinfraclaw

Testing [dashpay/rust-dashcore#579](https://github.com/dashpay/rust-dashcore/pull/579) (chore(ffi): move header files generation to the target directory) against this repo.

**Changes:** Updated `dashcore` and `dashcore-rpc` dependencies to use rev `8cbae416458565faac21d3452fbc6d80b324f6d3` (was tag v0.40.0).

This PR will be closed after CI results are recorded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to a specific commit version for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->