### PR TITLE
[CI] Test rust-dashcore PR #579

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 
 [dependencies]
 # dash-sdk = { git = "https://github.com/dashpay/platform", tag = "v1.8.0" }
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", tag = "v0.40.0", default-features = false, features = [
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "8cbae416458565faac21d3452fbc6d80b324f6d3", default-features = false, features = [
     "std",
     "secp-recovery",
     "bincode",
 ] }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", tag = "v0.40.0" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "8cbae416458565faac21d3452fbc6d80b324f6d3" }
 crossbeam-channel = "0.5.13"
 futures = "0.3.31"
 serde = { version = "1.0.217", features = ["derive"] }


### PR DESCRIPTION
Automated integration test for [dashpay/rust-dashcore#579](https://github.com/dashpay/rust-dashcore/pull/579).

This PR updates the rust-dashcore dependency to commit `8cbae416458565faac21d3452fbc6d80b324f6d3` to verify downstream compatibility.

**This PR will be automatically closed after CI results are collected.**

---
_Triggered by @ktechmidas via `@dashinfraclaw fulltest`_