### PR TITLE
chore: update rust-dashcore dependency to store TransactionContext in TransactionRecord

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 
 [dependencies]
 # dash-sdk = { git = "https://github.com/dashpay/platform", tag = "v1.8.0" }
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", tag = "v0.40.0", default-features = false, features = [
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "5114330ae564858803d656efba84bb4adacb2a2e", default-features = false, features = [
     "std",
     "secp-recovery",
     "bincode",
 ] }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", tag = "v0.40.0" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "5114330ae564858803d656efba84bb4adacb2a2e" }
 crossbeam-channel = "0.5.13"
 futures = "0.3.31"
 serde = { version = "1.0.217", features = ["derive"] }


### PR DESCRIPTION
Automated integration test for [dashpay/rust-dashcore#582](https://github.com/dashpay/rust-dashcore/pull/582).

**What:** Updated all `dashcore`/`dashcore-rpc` git dependencies to PR HEAD commit (`5114330ae564858803d656efba84bb4adacb2a2e`).

**Why:** Validates that the changes in rust-dashcore PR #582 (`refactor: store TransactionContext in TransactionRecord`) compile and pass CI against this repository.

**Changes:** Dependency pointer update only — no functional code changes.